### PR TITLE
Fixed modified ProductSlug. Added new dependency from 6.23.4.

### DIFF
--- a/gpdb/download.go
+++ b/gpdb/download.go
@@ -15,7 +15,7 @@ const (
 	EndPoint                     = "https://network.pivotal.io"
 	RefreshToken                 = EndPoint + "/api/v2/authentication/access_tokens"
 	Products                     = EndPoint + "/api/v2/products"
-	ProductSlug                  = "vmware-tanzu-greenplum" // we only care about this slug rest we ignore # old slug "pivotal-gpdb"
+	ProductSlug                  = "vmware-greenplum" // we only care about this slug rest we ignore # old slug "pivotal-gpdb"
 	CommandCenterSlug            = "gpdb-command-center"
 	OpenSourceReleaseAPIEndpoint = "https://api.github.com/repos/greenplum-db/gpdb/releases"
 )

--- a/gpdb/installGPDB.go
+++ b/gpdb/installGPDB.go
@@ -12,7 +12,7 @@ import (
 //GPDB v6 CentOS 7 dependencies from Docs
 var dependencies = []string{"apr-util", "bash", "bzip2", "curl", "krb5", "libcurl", "libevent", "libxml2",
 	"libyaml", "zlib", "openldap", "openssh", "openssl", "openssl-libs", "perl", "readline", "rsync", "R",
-	"sed", "tar", "zip", "krb5-devel"}
+	"sed", "tar", "zip", "krb5-devel", "libcgroup-tools"}
 
 // Precheck before installing GPDB
 func (i *Installation) preGPDBChecks() {


### PR DESCRIPTION
- ProductSlug on Tanzunet was changed from "vmware-tanzu-greenplum" to "vmware-greenplum".
- libcgroup-tools was added as a new dependency in 6.23.4.